### PR TITLE
Fixed behavior Functions_UnregisterMe() and added Admin_UnregisterMe()

### DIFF
--- a/addons/sourcemod/scripting/shop.sp
+++ b/addons/sourcemod/scripting/shop.sp
@@ -100,6 +100,7 @@ public int Native_UnregisterMe(Handle plugin, int params)
 {
 	ItemManager_UnregisterMe(plugin);
 	Functions_UnregisterMe(plugin);
+	Admin_UnregisterMe(plugin);
 }
 
 public int Native_ShowItemPanel(Handle plugin, int params)

--- a/addons/sourcemod/scripting/shop/admin.sp
+++ b/addons/sourcemod/scripting/shop/admin.sp
@@ -74,6 +74,18 @@ public int Admin_ShowAdminMenu(Handle plugin, int numParams)
 	Admin_ShowMenu(client);
 }
 
+void Admin_UnregisterMe(Handle hPlugin)
+{
+	int index = -1;
+	while ((index = g_hAdminArray.FindValue(hPlugin)) != -1)
+	{
+		delete view_as<Handle>(g_hAdminArray.Get(index+1));
+
+		g_hAdminArray.Erase(index);
+		g_hAdminArray.Erase(index);
+	}
+}
+
 void Admin_OnSettingsLoad(KeyValues kv)
 {
 	count_menu = new Menu(Admin_MenuCount_Handler, MENU_ACTIONS_DEFAULT|MenuAction_Display);

--- a/addons/sourcemod/scripting/shop/functions.sp
+++ b/addons/sourcemod/scripting/shop/functions.sp
@@ -113,9 +113,12 @@ public void Functions_OnConVarChange(ConVar convar, const char[] oldValue, const
 void Functions_UnregisterMe(Handle plugin)
 {
 	int index = -1;
-	while ((index = FindValueInArray(g_hFuncArray, plugin)) != -1)
+	while ((index = g_hFuncArray.FindValue(plugin)) != -1)
 	{
-		RemoveFromArray(g_hFuncArray, index);
+		delete view_as<Handle>(g_hFuncArray.Get(index+1));
+
+		g_hFuncArray.Erase(index);
+		g_hFuncArray.Erase(index);
 	}
 }
 


### PR DESCRIPTION
After last syntax (and not only) update, `Functions_UnregisterMe()` did not delete fully custom functions. This PR fixes this.
Also added `Admin_UnregisterMe()` for unregistering admin functions.