### PR TITLE
Memory Leak Fix and some pretty changes

### DIFF
--- a/addons/sourcemod/scripting/shop.sp
+++ b/addons/sourcemod/scripting/shop.sp
@@ -384,7 +384,7 @@ void DatabaseClear()
 	PlayerManager_DatabaseClear();
 }
 
-bool IsInGame(int player_id)
+stock bool IsInGame(int player_id)
 {
 	return PlayerManager_IsInGame(player_id);
 }

--- a/addons/sourcemod/scripting/shop/db.sp
+++ b/addons/sourcemod/scripting/shop/db.sp
@@ -127,7 +127,7 @@ public Action DB_Command_Clear(int argc)
 			{
 				iDays = -1;
 				
-				PrintToServer("[Shop] Database clear cancelled!");
+				PrintToServer("[Shop] Database clear canceled!");
 			}
 			else
 			{

--- a/addons/sourcemod/scripting/shop/db.sp
+++ b/addons/sourcemod/scripting/shop/db.sp
@@ -140,7 +140,7 @@ public Action DB_Command_Clear(int argc)
 				{
 					PrintToServer("[Shop] Current clearing option is set to - Clear from inactive players for more than %d %s!", iDays, (iDays == 1) ? "day" : "days");
 				}
-				PrintToServer("[Shop] Type sm_shop_clear_db 'ok' to process the query or 'cancel' to cancel the process!");
+				PrintToServer("[Shop] Type sm_shop_clear_db 'ok' to process the query or 'deny' to cancel the process!");
 			}
 			
 			return Plugin_Handled;

--- a/addons/sourcemod/scripting/shop/player_manager.sp
+++ b/addons/sourcemod/scripting/shop/player_manager.sp
@@ -1007,7 +1007,7 @@ void PlayerManager_DatabaseClear()
 	}
 }
 
-bool PlayerManager_IsInGame(int player_id)
+stock bool PlayerManager_IsInGame(int player_id)
 {
 	for (int i = 1; i <= MaxClients; i++)
 	{


### PR DESCRIPTION
- Fixed memory leak with DB_TQuery if players very many.
- Optimized queries to delete inactive players by days count.
- Changed `denied` to `canceled` into string after sending in server console `sm_shop_clear_db deny`

This fixes bug when SourceMod unloads Shop with 20 thousands "unclosed" `IDatabase` handles.
This fix has been tested with SQLite database from @samoletik1337
![default](https://user-images.githubusercontent.com/12576822/36478111-06b1d28e-171d-11e8-9eb8-1e301d94ed4d.png)
